### PR TITLE
Make the CI tests verbose

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -38,4 +38,4 @@ jobs:
         jupyter: true
     - name: Test with pytest
       run: |
-        poetry run pytest
+        poetry run pytest -vvv


### PR DESCRIPTION
This PR makes the existing CI tests verbose so we can identify issues directly from the GitHub Action logs.