### PR TITLE
Offline DSI simulation: Immediate pruning

### DIFF
--- a/dsi/offline/simul/dsi.py
+++ b/dsi/offline/simul/dsi.py
@@ -18,6 +18,7 @@ class SimulDSI(Simul):
         cost: float = 0
         toks: int = 0
         iters: int = 0
+        verified: bool = False
         while toks < self.config.S:
             new_toks: int = 0
             si: float = 0
@@ -28,12 +29,18 @@ class SimulDSI(Simul):
                 )  # curr_k >= 0
                 accepted: int = min(curr_k, next(self._sampler))  # accepted >= 0
                 new_toks += accepted
-                si += curr_k * self.config.c
+                if (accepted > 0) or (not verified):
+                    # Since the logits vector for the first position in the current
+                    # iteration is known once the target verifying the previous
+                    # iteration is done, we terminate the bad thread immediately.
+                    si += curr_k * self.config.c
                 if (curr_k == 0) or (accepted < curr_k):
                     # At least one draft is rejected
                     si += self.config.failure_cost
                     new_toks += 1
+                    verified = True
                     break
+                verified = False
             nonsi: float = new_toks * self.config.failure_cost
             cost += min(si, nonsi)
             toks += new_toks


### PR DESCRIPTION
This PR improves the accuracy of the offline DSI simulation by considering the following edge case where the first draft token of an iteration is rejected. This PR increases DSI speedups only slightly. The plots for `ndim=50` in [this](https://github.com/keyboardAnt/distributed-speculative-inference/pull/31) setting do not change.

The edge case: If the current iteration's first draft token is rejected, we do not necessarily need to incur the latency of drafting. We incur the latency of drafting only if we didn't incur the latency of verifying the previous iteration. Note that the edge case [holds](https://github.com/keyboardAnt/distributed-speculative-inference/pull/30#discussion_r1677205050) for the online DSI simulation.