### PR TITLE
Online tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-python.python"
+				"ms-python.python",
+				"ms-azuretools.vscode-docker"
 			]
 		}
 	}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -36,6 +36,6 @@ jobs:
       with:
         options: "--check --verbose"
         jupyter: true
-    - name: Test with pytest
+    - name: Test
       run: |
-        poetry run pytest -vvv
+        poetry run python ./scripts/test.py all -- -vvv

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,5 +39,16 @@
                 "heatmap.online=True"
             ]
         },
+        {
+            "name": "test",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "scripts.test",
+            "args": [
+                "all",
+                "--",
+                "-vvv",
+            ]
+        },
     ]
 }

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ By default, running new experiments will also visualize the results. To visualiz
 
 Run tests: `python ./scripts/test.py all` (from the project root)
 
-It runs tests that measure wall time serially and then the rest of the tests in parallel. You can run only the online tests (for example, with `python ./scripts/test.py serial -- -vvv`) or only the offline (`poetry run python ./scripts/test.py notserial -- -vvv`).
+It runs tests that measure wall time serially and then the rest of the tests in parallel. You can run only the online tests (for example, with `python ./scripts/test.py online -- -vvv`) or only the offline (`poetry run python ./scripts/test.py offline -- -vvv`).
 
 #### Formatting
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ By default, running new experiments will also visualize the results. To visualiz
 
 Run tests: `./scripts/test.sh` (from the project root)
 
-It runs tests that measure wall time serially and then the rest of the tests in parallel.
+It runs tests that measure wall time serially and then the rest of the tests in parallel. Configuring the tests is as easy as passing PyTest arguments (for example, `./scripts/test.sh -vvv`).
 
 #### Formatting
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ By default, running new experiments will also visualize the results. To visualiz
 
 [![Python tests](https://github.com/keyboardAnt/distributed-speculative-inference/actions/workflows/python-tests.yaml/badge.svg)](https://github.com/keyboardAnt/distributed-speculative-inference/actions/workflows/python-tests.yaml)
 
-Run tests: `./scripts/test.sh` (from the project root)
+Run tests: `python ./scripts/test.py all` (from the project root)
 
-It runs tests that measure wall time serially and then the rest of the tests in parallel. Configuring the tests is as easy as passing PyTest arguments (for example, `./scripts/test.sh -vvv`).
+It runs tests that measure wall time serially and then the rest of the tests in parallel. You can run only the online tests (for example, with `python ./scripts/test.py serial -- -vvv`) or only the offline (`poetry run python ./scripts/test.py notserial -- -vvv`).
 
 #### Formatting
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ By default, running new experiments will also visualize the results. To visualiz
 
 [![Python tests](https://github.com/keyboardAnt/distributed-speculative-inference/actions/workflows/python-tests.yaml/badge.svg)](https://github.com/keyboardAnt/distributed-speculative-inference/actions/workflows/python-tests.yaml)
 
-Run tests: `python -m pytest` (from the project root)
+Run tests: `./scripts/test.sh` (from the project root)
+
+It runs tests that measure wall time serially and then the rest of the tests in parallel.
 
 #### Formatting
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2595,6 +2595,7 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
+    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_aarch64.whl", hash = "sha256:98103729cc5226e13ca319a10bbf9433bbbd44ef64fe72f45f067cacc14b8d27"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f9b37bc5c8cf7509665cb6ada5aaa0ce65618f2332b7d3e78e9790511f111212"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-win_amd64.whl", hash = "sha256:e782564d705ff0bf61ac3e1bf730166da66dd2fe9012f111ede5fc49b64ae697"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1226,6 +1226,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "filelock"
 version = "3.15.4"
 description = "A platform independent file lock."
@@ -3426,6 +3440,26 @@ files = [
 pytest = ">=7.0.0"
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -4978,4 +5012,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.14"
-content-hash = "6d75446da3dbb0cf9edd9b24fc46ed8a7b2bed8fb3fdc09e263b15d36210d98d"
+content-hash = "5f390dbefd473df98179913608e32db2bb0e9c22bf2b29d39a34584a7f0c6629"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ black = "^24.4.2"
 isort = "^5.13.2"
 pytest-mock = "^3.14.0"
 pytest-timeout = "^2.3.1"
+pytest-xdist = "^3.6.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 markers =
-    serial
+    online

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    serial

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,45 @@
+import argparse
+import subprocess
+from enum import Enum
+
+
+class TestMarker(Enum):
+    SERIAL = "serial"
+    NOTSERIAL = "not serial"
+    ALL = "all"  # Adding 'all' as a valid TestMarker
+
+
+def run_pytest(marker: TestMarker, pytest_args):
+    """Helper method to run pytest with given markers and additional arguments."""
+    if marker in [TestMarker.SERIAL, TestMarker.NOTSERIAL]:
+        n_option = "0" if marker == TestMarker.SERIAL else "auto"
+        cmd = ["pytest", "-m", marker.value, "-n", n_option] + pytest_args
+        print("Executing command:", " ".join(cmd))
+        subprocess.run(cmd)
+    elif marker == TestMarker.ALL:
+        print("Running all tests...")
+        run_pytest(TestMarker.SERIAL, pytest_args)
+        run_pytest(TestMarker.NOTSERIAL, pytest_args)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run pytest with different modes.")
+    parser.add_argument(
+        "mode",
+        choices=[marker.name.lower() for marker in TestMarker],
+        help="The mode to run tests in.",
+    )
+    parser.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments to pass to pytest",
+    )
+
+    args = parser.parse_args()
+
+    marker = TestMarker[args.mode.upper()]
+    run_pytest(marker, args.pytest_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -4,24 +4,24 @@ from enum import Enum
 
 
 class TestMarker(Enum):
-    SERIAL = "serial"
-    NOTSERIAL = "not serial"
+    ONLINE = "online"
+    OFFLINE = "not online"
     ALL = "all"  # Adding 'all' as a valid TestMarker
 
 
 def run_pytest(marker: TestMarker, pytest_args):
     """Helper method to run pytest with given markers and additional arguments."""
-    if marker in [TestMarker.SERIAL, TestMarker.NOTSERIAL]:
-        n_option = "0" if marker == TestMarker.SERIAL else "auto"
+    if marker in [TestMarker.ONLINE, TestMarker.OFFLINE]:
+        n_option = "0" if marker == TestMarker.ONLINE else "auto"
         cmd = ["pytest", "-m", marker.value, "-n", n_option] + pytest_args
         print("Executing command:", " ".join(cmd))
         subprocess.run(cmd)
     elif marker == TestMarker.ALL:
         print("Running all tests...")
-        print("1. Running serial tests...")
-        run_pytest(TestMarker.SERIAL, pytest_args)
-        print("2. Running non-serial tests...")
-        run_pytest(TestMarker.NOTSERIAL, pytest_args)
+        print("1. Running online tests...")
+        run_pytest(TestMarker.ONLINE, pytest_args)
+        print("2. Running offline tests...")
+        run_pytest(TestMarker.OFFLINE, pytest_args)
 
 
 def main():

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -18,7 +18,9 @@ def run_pytest(marker: TestMarker, pytest_args):
         subprocess.run(cmd)
     elif marker == TestMarker.ALL:
         print("Running all tests...")
+        print("1. Running serial tests...")
         run_pytest(TestMarker.SERIAL, pytest_args)
+        print("2. Running non-serial tests...")
         run_pytest(TestMarker.NOTSERIAL, pytest_args)
 
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo "Running serial tests..."
-pytest -m "serial" -n 0
-
-echo "Running parallel tests..."
-pytest -m "not serial" -n auto

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Running serial tests..."
+pytest -m "serial" -n 0
+
+echo "Running parallel tests..."
+pytest -m "not serial" -n auto


### PR DESCRIPTION
This PR primarily adds support in online tests:

- adds `scripts/test.py` that distinguishes online tests and runs them serially while executing the rest of the tests in parallel
- adds the online test `test_num_of_fix_history`
- updates the CI